### PR TITLE
Add a nav_link helper

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -23,3 +23,16 @@ activate :deploy do |deploy|
   deploy.build_before = true
   deploy.method = :git
 end
+
+helpers do
+  def nav_link(link_text, page_url, options = {})
+    options[:class] ||= ""
+    if current_page.url.length > 1
+      current_url = current_page.url.chop
+    else
+      current_url = current_page.url
+    end
+    options[:class] << " active" if page_url == current_url
+    link_to(link_text, page_url, options)
+  end
+end


### PR DESCRIPTION
Enables Ember-like link functionality. When using the nav_link helper, a
link to your current page gets an "active" class.
