### PR TITLE
correct sh syntax

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -13,7 +13,7 @@ echo -e "Installing Dependencies..."
 bundle install
 
 # Remove Git remote if it's still the proteus-middleman repo
-if [ `git config --get remote.origin.url` == "git@github.com:thoughtbot/proteus-middleman.git" ]; then
+if [ `git config --get remote.origin.url` = "git@github.com:thoughtbot/proteus-middleman.git" ]; then
   git remote rm origin
   echo -e "Resetting Git remote. What is your repo url?"
   read url


### PR DESCRIPTION
because POSIX sh doesn't understand `==` for string equality,

* though it is valid bash syntax
* we use `=` instead!