### PR TITLE
Support Middleman 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,9 @@
 # the following line to use "https"
 source "http://rubygems.org"
 
-gem "middleman"
+gem "middleman", ">= 4.0.0"
 gem "middleman-autoprefixer"
-gem "middleman-deploy"
+gem "middleman-deploy", "= 2.0.0.pre.alpha"
 gem "middleman-livereload"
 gem "bourbon"
 gem "neat"

--- a/config.rb
+++ b/config.rb
@@ -22,7 +22,7 @@ end
 
 activate :deploy do |deploy|
   deploy.build_before = true
-  deploy.method = :git
+  deploy.deploy_method = :git
 end
 
 helpers do

--- a/extensions/views.rb
+++ b/extensions/views.rb
@@ -1,5 +1,5 @@
 class Middleman::Extensions::ViewsDirectory < Middleman::Extension
-  register :views
+  ::Middleman::Extensions.register(:views, self)
   option   :views_dir, 'views', 'Directory for site views'
 
   def manipulate_resource_list resources


### PR DESCRIPTION
Attempting to generate a Middleman site with Proteus using [Middleman
4][1] resulted in several errors when starting the server.

This resolves those errors by:

* Using an [updated syntax][2] for registering extensions
* Updating `middleman-deploy` to [an alpha version that supports Middleman
  4][3]

---

An alternative to using a pre-release version of `middleman-deploy` would be to lock `middleman` in the `Gemfile` to `~> 3.4.1`.

I don't have much experience with Middleman, and haven't had done a lot of testing of these changes beyond getting the server started with a newly-generated site, but this update seems to resolve the issues I encountered. Happy to hear feedback on these changes.

[1]: https://middlemanapp.com/basics/upgrade-v4/
[2]: https://middlemanapp.com/advanced/custom_extensions/#basic-extension
[3]: https://github.com/middleman-contrib/middleman-deploy/issues/100#issuecomment-148635762