### PR TITLE
Use bundle exec when running middleman commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ bundle install
 
 Run the server
 ```
-middleman
+bundle exec middleman
 ```
 
 Deploy to Github Pages
 ```
-middleman deploy
+bundle exec middleman deploy
 ```
 
 Or install the [Proteus gem](https://github.com/thoughtbot/proteus) and enjoy some shortcuts.


### PR DESCRIPTION
I can’t really speak to why…but I’ve been told this is best practice.

The server won’t run for me without doing this.