### PR TITLE
Import Normalize first

### DIFF
--- a/source/assets/stylesheets/application.css.scss
+++ b/source/assets/stylesheets/application.css.scss
@@ -1,7 +1,7 @@
+@import "vendor/normalize";
+
 @import "bourbon";
 @import "base/base";
 @import "neat";
-
-@import "vendor/normalize";
 
 @import "global";


### PR DESCRIPTION
It's usually best practice to import any sort of "reset" first. Right now, any
styles within the Bitters instance run the risk of being overriden by styles
in Normalize.